### PR TITLE
GH API call retry

### DIFF
--- a/tasks/install-caddy.yml
+++ b/tasks/install-caddy.yml
@@ -14,6 +14,9 @@
     url: "{{ _caddy_github_api_url }}"
     method: GET
   register: _caddy_github_release
+  until: _caddy_github_release.status == 200
+  retries: 5
+  delay: 15
 
 - name: Get Caddy's latest release tag
   set_fact:


### PR DESCRIPTION
Retry the GH API call on failure (e.g. when hitting the rate-limiting quota)